### PR TITLE
Fix BLE connect when kettle is idle (no advertisement)

### DIFF
--- a/custom_components/fellow_stagg/__init__.py
+++ b/custom_components/fellow_stagg/__init__.py
@@ -5,6 +5,8 @@ from typing import Any
 
 from homeassistant.components.bluetooth import (
     async_ble_device_from_address,
+    async_last_service_info,
+    async_scanner_by_source,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform, UnitOfTemperature
@@ -43,6 +45,7 @@ class FellowStaggDataUpdateCoordinator(DataUpdateCoordinator):
     self.ble_device = None
     self._address = address
     self.entry_id = entry_id
+    self._last_service_info = None  # cached for idle-kettle directed connect
 
     self.device_info = DeviceInfo(
       identifiers={(DOMAIN, address)},
@@ -66,15 +69,64 @@ class FellowStaggDataUpdateCoordinator(DataUpdateCoordinator):
     """Get the maximum temperature based on current units."""
     return MAX_TEMP_F if self.temperature_unit == UnitOfTemperature.FAHRENHEIT else MAX_TEMP_C
 
+  def _inject_cached_ble_device(self) -> None:
+    """Re-insert the last known service info into the BLE scanner cache.
+
+    The kettle stops advertising after ~3 min idle but accepts directed connections.
+    HA's BLE routing requires a live scanner cache entry to route through the proxy.
+    Injecting the cached entry with a current timestamp unblocks routing; the proxy
+    then initiates the directed BLE connection by address.
+    """
+    service_info = self._last_service_info
+    if service_info is None:
+      return
+    try:
+      from bluetooth_data_tools import monotonic_time_coarse
+      service_info.time = monotonic_time_coarse()
+    except Exception:
+      pass
+    scanner = async_scanner_by_source(self.hass, service_info.source)
+    if scanner is not None:
+      scanner._previous_service_info[self._address] = service_info
+      _LOGGER.debug(
+        "Injected cached BLE device for %s via scanner %s for directed connect",
+        self._address, service_info.source,
+      )
+
+  def get_ble_device_for_connect(self):
+    """Return the best available BLEDevice, injecting cached state if needed.
+
+    Returns the live device if present, the cached device after cache injection
+    if available, or None if no prior advertisement has ever been seen.
+    """
+    ble_device = async_ble_device_from_address(self.hass, self._address, True)
+    if ble_device is not None:
+      return ble_device
+    if self._last_service_info is not None:
+      self._inject_cached_ble_device()
+      return self._last_service_info.device
+    return None
+
   async def _async_update_data(self) -> dict[str, Any] | None:
     """Fetch data from the kettle."""
     _LOGGER.debug("Starting poll for Fellow Stagg kettle %s", self._address)
-    
+
     self.ble_device = async_ble_device_from_address(self.hass, self._address, True)
     if not self.ble_device:
-      _LOGGER.debug("No connectable device found")
-      return None
-        
+      if self._last_service_info is not None:
+        _LOGGER.debug(
+          "No advertisement in cache; injecting cached service info for directed connect to %s",
+          self._address,
+        )
+        self._inject_cached_ble_device()
+        self.ble_device = self._last_service_info.device
+      else:
+        _LOGGER.debug(
+          "No advertisement and no cached service info for %s; skipping poll",
+          self._address,
+        )
+        return None
+
     try:
       _LOGGER.debug("Attempting to poll kettle data...")
       data = await self.kettle.async_poll(self.ble_device)
@@ -83,17 +135,22 @@ class FellowStaggDataUpdateCoordinator(DataUpdateCoordinator):
         self._address,
         data,
       )
-      
+
+      # Update cache after a successful poll
+      fresh_info = async_last_service_info(self.hass, self._address, True)
+      if fresh_info is not None:
+        self._last_service_info = fresh_info
+
       # Log any changes in data compared to previous state
       if self.data is not None:
         changes = {
-          k: (self.data.get(k), v) 
-          for k, v in data.items() 
+          k: (self.data.get(k), v)
+          for k, v in data.items()
           if k in self.data and self.data.get(k) != v
         }
         if changes:
           _LOGGER.debug("Data changes detected: %s", changes)
-      
+
       return data
     except Exception as e:
       _LOGGER.error(
@@ -126,7 +183,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
   hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 
   await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-  
+
   _LOGGER.debug("Setup complete for Fellow Stagg device: %s", address)
   return True
 

--- a/custom_components/fellow_stagg/switch.py
+++ b/custom_components/fellow_stagg/switch.py
@@ -49,7 +49,8 @@ class FellowStaggPowerSwitch(SwitchEntity):
   async def async_turn_on(self, **kwargs: Any) -> None:
     """Turn the switch on."""
     _LOGGER.debug("Turning power switch ON")
-    await self.coordinator.kettle.async_set_power(self.coordinator.ble_device, True)
+    ble_device = self.coordinator.get_ble_device_for_connect()
+    await self.coordinator.kettle.async_set_power(ble_device, True)
     _LOGGER.debug("Power ON command sent, waiting before refresh")
     # Give the kettle a moment to update its internal state
     await asyncio.sleep(0.5)
@@ -59,7 +60,8 @@ class FellowStaggPowerSwitch(SwitchEntity):
   async def async_turn_off(self, **kwargs: Any) -> None:
     """Turn the switch off."""
     _LOGGER.debug("Turning power switch OFF")
-    await self.coordinator.kettle.async_set_power(self.coordinator.ble_device, False)
+    ble_device = self.coordinator.get_ble_device_for_connect()
+    await self.coordinator.kettle.async_set_power(ble_device, False)
     _LOGGER.debug("Power OFF command sent, waiting before refresh")
     # Give the kettle a moment to update its internal state
     await asyncio.sleep(0.5)


### PR DESCRIPTION
Adds a directed-connect fallback for when the Stagg has stopped advertising, which is the underlying connectivity gap behind #5 on setups that use an ESP32 BLE proxy.

## Bug

After a few minutes idle, the kettle stops broadcasting BLE advertisements. With an ESP32 BLE proxy, `async_ble_device_from_address(..., connectable=True)` returns None because the scanner cache is empty. Subsequent polls and user-initiated `switch.turn_on` calls fail. (#5 surfaces the visible crash from the entity-property side; this PR addresses the connectivity gap that produces the None in the first place.)

## Fix

The kettle still accepts directed connections by address even when it isn't advertising. The patch:

1. Caches the most recent successful `async_last_service_info` on every successful poll.
2. When a poll finds no live BLE device, re-injects the cached service info (with a refreshed timestamp) into the matching scanner's `_previous_service_info`. HA can then resolve the address and the proxy initiates a directed connection.
3. `switch.async_turn_on` / `async_turn_off` resolve the BLEDevice via a new helper that does the same fallback, so user-initiated power commands work even if the coordinator's last poll didn't see the kettle.

## Testing

In production ~9 days on a Mac Mini Home Assistant install with one ESP32-S3 BLE proxy and a Stagg EKG+ (original). Weekday-morning automation triggers `switch.turn_on` daily; reliable when the kettle has been idle overnight, which was the failure mode before the patch.

No unit tests, and I don't have other proxy / kettle hardware to validate against. Reviewer judgment welcome on the cache-injection approach. It touches the scanner's internal `_previous_service_info` dict, which is technically private.

## AI authorship disclosure

This patch was written by Claude (Anthropic's coding assistant) at my direction. I run it in production daily and can speak to its real-world behavior, but I'm not skilled enough in HA internals or async BLE to vet the implementation line by line. Please review it as you would any AI-authored contribution.

Noted your earlier GPT-Pro analysis on #5 proposing defensive `.data` guards and `UpdateFailed` instead of returning None. That's a different and complementary fix path; this PR is intentionally narrower (just the connectivity restoration). Happy to follow up with a separate PR for those guards if you want them, but it felt cleaner to keep the scopes split.